### PR TITLE
Minor fixes for packaging

### DIFF
--- a/ink-mode.el
+++ b/ink-mode.el
@@ -7,7 +7,7 @@
 ;; URL: http://github.com/Kungsgeten/ink-mode
 ;; Version: 0.1
 ;; Keywords: languages
-;; Package-Requires: ()
+;; Package-Requires: ((emacs "24.3"))
 
 ;;; Commentary:
 
@@ -82,6 +82,7 @@
        (apply 'make-comint-in-buffer "Ink" buffer
               ink-inklecate-path nil `("-p" ,(buffer-file-name)))))))
 
+;;;###autoload
 (define-derived-mode ink-mode
   prog-mode "Ink"
   "Major mode for editing interactive fiction using the Ink


### PR DESCRIPTION
- Add autoload for 'ink-mode, without which the autoloaded 'auto-mode-alist entry will cause errors
- Depend on Emacs 24.3, for 'setq-local

In connection with https://github.com/melpa/melpa/pull/4138