### PR TITLE
Define group for customize and byte-compile warning

### DIFF
--- a/ink-mode.el
+++ b/ink-mode.el
@@ -18,6 +18,10 @@
 ;;; Code:
 (require 'rx)
 
+(defgroup ink nil
+  "Major mode for writing interactive fiction in Ink."
+  :group 'languages)
+
 (defvar ink-mode-hook nil)
 
 (defvar ink-mode-map


### PR DESCRIPTION
This fixes following byte-compile warning.

```
ink-mode.el:37:1:Warning: defface for ‘ink-condition-face’ fails to specify containing group
```