### PR TITLE
Brief snippet docs, Wrap comint mode

### DIFF
--- a/README.org
+++ b/README.org
@@ -41,19 +41,6 @@ requiring ink-mode:
   (add-hook 'ink-mode-hook 'flymake-mode)
 #+END_SRC
 
-** Snippets
-
-See ~snippets/ink-mode/*~ for snippet definitions.
-
-| Snippet             | Key |
-| choice once         | co  |
-| choice sticky       | cs  |
-| condition           | cd  |
-| multiline condition | mlc |
-| divert              | dv  |
-| knot                | kt  |
-| stitch              | st  |
-
 ** License
 This program is free software: you can redistribute it and/or modify
 it under the terms of the [[COPYING][GNU General Public License]] as published by

--- a/README.org
+++ b/README.org
@@ -41,6 +41,19 @@ requiring ink-mode:
   (add-hook 'ink-mode-hook 'flymake-mode)
 #+END_SRC
 
+** Snippets
+
+See ~snippets/ink-mode/*~ for snippet definitions.
+
+| Snippet             | Key |
+| choice once         | co  |
+| choice sticky       | cs  |
+| condition           | cd  |
+| multiline condition | mlc |
+| divert              | dv  |
+| knot                | kt  |
+| stitch              | st  |
+
 ** License
 This program is free software: you can redistribute it and/or modify
 it under the terms of the [[COPYING][GNU General Public License]] as published by

--- a/ink-mode.el
+++ b/ink-mode.el
@@ -784,10 +784,7 @@ ink-play and ink-play-knot commands in the same buffer.")
 (define-derived-mode ink-play-mode comint-mode "Ink-Play"
   "Major mode for `ink-play'.
 
-Derives from comint-mode, adds a few ink bindings.
-
-Support `describe-mode' referencing our keymap:
-//{ink-play-mode-map}")
+Derives from comint-mode, adds a few ink bindings.")
 
 (easy-menu-define ink-play-mode-menu ink-play-mode-map
   "Menu for `ink-play-mode'."

--- a/ink-mode.el
+++ b/ink-mode.el
@@ -810,7 +810,7 @@ the process, and suppress the beginning output using the comint
 output filter."
   (interactive "P")
   (let* (;; check this ahead of (set-buffer)
-         (in-ink-play-buffer (string= "*Ink*" (buffer-name (current-buffer))))
+         (in-ink-play-buffer (equal major-mode 'ink-play-mode))
 
          ;; if our buffer isn't referring to a real file (eg. *Ink*),
          ;; use the cached last-file-name
@@ -820,11 +820,11 @@ output filter."
          ;; needs to run before set-buffer call
          (knot-name (when go-to-knot
                       (if in-ink-play-buffer
-                           ;; return the last played knot
-                           ink-last-played-knot
-                           ;; return a knot name if found, nil otherwise
-                           (let ((x (ink-get-knot-name)))
-                             (unless (eq "" x) x)))))
+                          ;; return the last played knot
+                          ink-last-played-knot
+                        ;; return a knot name if found, nil otherwise
+                        (let ((kn (ink-get-knot-name)))
+                          (unless (string-empty-p kn) kn)))))
 
          (ink-buffer
           (if (or

--- a/ink-mode.el
+++ b/ink-mode.el
@@ -786,11 +786,6 @@ ink-play and ink-play-knot commands in the same buffer.")
 
 Derives from comint-mode, adds a few ink bindings.")
 
-(easy-menu-define ink-play-mode-menu ink-play-mode-map
-  "Menu for `ink-play-mode'."
-  '("Ink-Play"
-    ["Open ink manual" ink-display-manual]))
-
 (defcustom ink-inklecate-path (executable-find "inklecate")
   "The path to the Inklecate executable."
   :group 'ink

--- a/ink-mode.el
+++ b/ink-mode.el
@@ -768,6 +768,27 @@ indent. INDENTATION is the current sum."
 
 ;;; Ink-play
 
+(defvar ink-play-mode-hook nil)
+
+(defvar ink-play-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "C-c C-h") 'ink-display-manual)
+    map)
+  "Keymap for ink-play mode.")
+
+(define-derived-mode ink-play-mode comint-mode "Ink-Play"
+  "Major mode for `ink-play'.
+
+Derives from comint-mode, adds a few ink bindings.
+Might be expanded to handle restart, rewind, or go-to-choice functionality.
+
+//{ink-play-mode-map}")
+
+(easy-menu-define ink-play-mode-menu ink-play-mode-map
+  "Menu for `ink-play-mode'."
+  '("Ink-Play"
+    ["Open ink manual" ink-display-manual]))
+
 (defcustom ink-inklecate-path (executable-find "inklecate")
   "The path to the Inklecate executable."
   :group 'ink
@@ -794,8 +815,13 @@ output filter."
                 (comint-exec "*Ink*" "Ink" ink-inklecate-path
                              nil `("-p" ,file-name))
                 "*Ink*")
-            (make-comint "Ink" ink-inklecate-path nil
-                         "-p" (buffer-file-name))))
+            (progn
+              (let ((new-buffer
+                     (make-comint "Ink" ink-inklecate-path nil
+                                  "-p" (buffer-file-name))))
+                (set-buffer new-buffer)
+                (ink-play-mode)
+                new-buffer))))
          (knot-name (ink-get-knot-name)))
     (switch-to-buffer-other-window ink-buffer)
     (comint-clear-buffer)


### PR DESCRIPTION
I can break these apart if you'd rather treat them separately.

Just some thoughts, feel free to take it or leave it. Many thanks for
the work on this mode, it has made learning ink completely within emacs
a great experience. The snippets and auto-completion are a delight!

--

feat: wrap comint with ink-play derived mode 

This wraps the comint-mode buffer used for running ink-play with a
derived mode called ink-play-mode, which adds a single keybinding for
jumping to the docs.

This isn't really necessary, but while reading the manual and testing
out examples, I was running examples and then wanting to jump back to
the docs. It's certainly possible to just set a keybinding elsewhere,
jump via buffer, or use `M-x ink-display-manual`, but I've seen comint
wrapped a few different ways recently and had never done it myself, so
took a shot at it here.

Ink-play mode could be expanded to rewind choices or restart the last
knot/stitch played at some point. Another idea could be writing a
binding to jump to the current choice/prompt from the 'play' buffer.

-- 

docs: add snippets section with keys

I was going through these myself to learn them, so thought I'd throw in
a docs section - feel free to take/leave/edit as you would.