### PR TITLE
Tests for indentation and font-lock + flymake fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 EASK ?= eask
 ELISP_FILES = ink-mode.el
 
-.PHONY: deps lint package-lint checkdoc compile test
+.PHONY: deps lint package-lint checkdoc compile test clean
 
 lint: checkdoc compile package-lint
 
@@ -19,3 +19,6 @@ compile:
 
 test:
 	$(EASK) test ert-runner
+
+clean:
+	rm -f *.elc test/*.elc

--- a/test/font-lock-test.el
+++ b/test/font-lock-test.el
@@ -1,0 +1,65 @@
+;;; font-lock-test.el --- tests for Ink font-lock highlighting  -*- lexical-binding: t; -*-
+
+(require 'ert)
+(require 'ink-mode)
+
+;; NOTE: Need this to silence the compiler when ert-font-lock is not
+;; available.
+(declare-function ert-font-lock-test-string "ert-font-lock" (test-string mode))
+
+(ert-deftest ink-font-lock-highlights-function-header-parts ()
+  (skip-when (not (require 'ert-font-lock nil t)))
+  (skip-unless (fboundp 'ert-font-lock-test-string))
+  (ert-font-lock-test-string
+   "
+=== function forest_phase(arg) ===
+// <- ink-shadow-face
+//  ^ font-lock-keyword-face
+//           ^ ink-knot-face
+//                       ^ font-lock-variable-name-face
+"
+   'ink-mode))
+
+(ert-deftest ink-font-lock-highlights-diverts-and-includes ()
+  (skip-when (not (require 'ert-font-lock nil t)))
+  (skip-unless (fboundp 'ert-font-lock-test-string))
+  (ert-font-lock-test-string
+   "
+-> ending
+// <- ink-arrow-face
+//  ^ ink-link-face
+INCLUDE chapter.ink
+// <- font-lock-keyword-face
+//      ^ ink-link-face
+"
+   'ink-mode))
+
+(ert-deftest ink-font-lock-highlights-choices-labels-and-brackets ()
+  (skip-when (not (require 'ert-font-lock nil t)))
+  (skip-unless (fboundp 'ert-font-lock-test-string))
+  (ert-font-lock-test-string
+   "
+* (choice_label) [Option text]
+// <- font-lock-type-face
+//  ^ font-lock-variable-name-face
+//                 ^ ink-bracket-face
+"
+   'ink-mode))
+
+(ert-deftest ink-font-lock-highlights-tags-glue-and-var-decls ()
+  (skip-when (not (require 'ert-font-lock nil t)))
+  (skip-unless (fboundp 'ert-font-lock-test-string))
+  (ert-font-lock-test-string
+   "
+Plain text #tag
+//         ^ ink-tag-face
+<>
+// <- ink-shadow-face
+VAR score = 0
+// <- font-lock-keyword-face
+//    ^ font-lock-variable-name-face
+"
+   'ink-mode))
+
+(provide 'font-lock-test)
+;;; font-lock-test.el ends here

--- a/test/imenu-test.el
+++ b/test/imenu-test.el
@@ -12,13 +12,6 @@
 * (end_choice) End choice
 ")
 
-(defun ink-test--line-position (line)
-  "Return beginning position of LINE in current buffer."
-  (save-excursion
-    (goto-char (point-min))
-    (should (search-forward line nil t))
-    (line-beginning-position)))
-
 (ert-deftest ink-collect-symbols-parses-headers-and-labels ()
   (with-temp-buffer
     (insert ink-test--sample-buffer)

--- a/test/indentation-test.el
+++ b/test/indentation-test.el
@@ -1,0 +1,63 @@
+;;; indentation-test.el --- tests for Ink indentation behavior  -*- lexical-binding: t; -*-
+
+(require 'ert)
+(require 'ink-mode)
+
+(ert-deftest ink-indent-handles-nested-choices-and-gathers ()
+  (should (equal
+           (ink-test--indent-string
+            "== start ==\n* top\n** deep\ntext\n- gather\ntext\n"
+            nil nil)
+           "== start ==\n  * top\n    * * deep\n        text\n- gather\n  text\n")))
+
+(ert-deftest ink-indent-handles-braced-conditions ()
+  (should (equal
+           (ink-test--indent-string
+            "== start ==\n{ cond:\n- yes:\ntext\n- no:\nother\n}\nafter\n"
+            nil nil)
+           "== start ==\n{ cond:\n- yes:\n  text\n- no:\n  other\n}\nafter\n")))
+
+(ert-deftest ink-indent-aligns-comment-and-todo-lines-with-following-content ()
+  (should (equal
+           (ink-test--indent-string
+            "== start ==\n* choice\n// comment\nTODO: later\ntext\n"
+            nil nil)
+           "== start ==\n  * choice\n    // comment\n    TODO: later\n    text\n")))
+
+(ert-deftest ink-indent-aligns-multiline-comments-with-following-content ()
+  (should (equal
+           (ink-test--indent-string
+            "== start ==\n/* block\ninside\n*/\n* choice\ntext\n"
+            nil nil)
+           "== start ==\n  /* block\n  inside\n  */\n  * choice\n    text\n")))
+
+(ert-deftest ink-indent-handles-trailing-newline-after-comment-content ()
+  (should (equal
+           (ink-test--indent-string
+            "== start ==\n* choice\n// comment\ntext\n"
+            nil nil)
+           "== start ==\n  * choice\n    // comment\n    text\n")))
+
+(ert-deftest ink-indent-choice-markers-use-tabs-by-default ()
+  (should (equal
+           (ink-test--indent-string
+            "== start ==\n* * [opt]\n"
+            t nil)
+           (concat "== start ==\n\t\t*\t*\t[opt]\n"))))
+
+(ert-deftest ink-indent-choice-markers-use-spaces-when-configured ()
+  (should (equal
+           (ink-test--indent-string
+            "== start ==\n* * [opt]\n"
+            nil t)
+           "== start ==\n    * * [opt]\n")))
+
+(ert-deftest ink-indent-choice-diverts-keep-the-arrow-adjacent ()
+  (should (equal
+           (ink-test--indent-string
+            "== start ==\n* -> somewhere\n"
+            t nil)
+           (concat "== start ==\n\t*\t-> somewhere\n"))))
+
+(provide 'indentation-test)
+;;; indentation-test.el ends here

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -1,0 +1,25 @@
+;;; test-helper.el --- shared helpers for ink-mode tests  -*- lexical-binding: t; -*-
+
+(require 'ink-mode)
+
+(defun ink-test--indent-string (input &optional indent-tabs choice-spaces)
+  "Return INPUT after indenting it in `ink-mode'."
+  (with-temp-buffer
+    (insert input)
+    (ink-mode)
+    (setq-local tab-width 2)
+    (setq-local indent-tabs-mode indent-tabs)
+    (setq-local ink-indent-choices-with-spaces choice-spaces)
+    (let ((inhibit-message t))
+      (indent-region (point-min) (point-max)))
+    (buffer-string)))
+
+(defun ink-test--line-position (line)
+  "Return beginning position of LINE in current buffer."
+  (save-excursion
+    (goto-char (point-min))
+    (should (search-forward line nil t))
+    (line-beginning-position)))
+
+(provide 'test-helper)
+;;; test-helper.el ends here


### PR DESCRIPTION
Included are:

- fixes a couple of corner cases in flymake command runs
- ert tests for the indentation engine
- ert tests for font-lock
- new Makefile task: clean 

But mostly tests. The point is to have a reliable testing harness for complicated parts of the mode.

Thanks!